### PR TITLE
check if the content-type is set before calling "split" on it.

### DIFF
--- a/index.js
+++ b/index.js
@@ -263,7 +263,7 @@ var Response = prime({
         this.text   = text
         this.status = status
 
-        var type   = header['Content-Type'].split(/ *; */).shift(),
+        var type   = header['Content-Type'] ? header['Content-Type'].split(/ *; */).shift() : '',
             decode = decoders[type]
 
         this.body = decode ? decode(this.text) : this.text


### PR DESCRIPTION
When "abort" is called on a Request prime the Reponse prime tries to parse the content-type which isn't set.
