### PR TITLE
RegEx issue for methods tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -351,7 +351,7 @@ var Response = prime({
 })
 
 var methods  = "get|post|put|delete|head|patch|options",
-    rMethods = new RegExp("^" + methods + "$", "i")
+    rMethods = new RegExp("^(" + methods + ")$", "i")
 
 var agent = function(method, url, data, callback){
     var request = new Request()


### PR DESCRIPTION
There's an issue with the regex for the methods where it's possible to have an url that matches some methods when it shouldn't.

``` js
rMethods.test("my_head_spins"); // returns true because matches head
```

Proposition is to force grouping the list of methods so that none of them leak.
